### PR TITLE
Faster cython

### DIFF
--- a/blackjack/cython-array/outcomes.py
+++ b/blackjack/cython-array/outcomes.py
@@ -1,0 +1,30 @@
+import partitions
+import array
+
+deck = ([4]*9)
+deck.append(16)
+
+deck = array.array('i', deck)
+
+d = 0
+
+for i in range(0, 10):
+
+    # Dealer showing
+
+    deck[i] = deck[i]-1
+
+    p = 0
+    for j in range(0, 10):
+        deck[j] = deck[j]-1
+        n = partitions.partitions(deck, j+1)
+        #print('Starting with ', j, n)
+        deck[j] = deck[j]+1
+        p += n
+
+    print('Dealer showing ', i,' partitions =',p)
+    d += p
+
+    deck[i] = deck[i]+1
+
+print('Total partitions =',d)

--- a/blackjack/cython-array/outcomes.txt
+++ b/blackjack/cython-array/outcomes.txt
@@ -1,0 +1,15 @@
+Dealer showing  0  partitions = 417334
+Dealer showing  1  partitions = 560954
+Dealer showing  2  partitions = 658854
+Dealer showing  3  partitions = 679464
+Dealer showing  4  partitions = 680299
+Dealer showing  5  partitions = 680305
+Dealer showing  6  partitions = 680305
+Dealer showing  7  partitions = 680305
+Dealer showing  8  partitions = 680305
+Dealer showing  9  partitions = 680305
+Total partitions = 6398430
+
+real	0m0.132s
+user	0m0.125s
+sys	0m0.006s

--- a/blackjack/cython-array/partitions.pyx
+++ b/blackjack/cython-array/partitions.pyx
@@ -1,0 +1,32 @@
+#cython: language_level=3, boundscheck=False, wraparound=False
+
+cpdef int partitions(int[:] cards, int subtotal):
+    cdef:
+        unsigned int i
+        int m, total
+
+    m = 0
+    # Hit
+    for i in range(0, 10):
+        if (cards[i]>0):
+
+            cards[i] = cards[i]-1
+            total = subtotal+i+1
+
+            if (total < 21):
+
+                # Stand
+                m += 1
+                #print(cards, total)
+                # Hit again
+                m += partitions(cards, total)
+
+            elif (total==21):
+
+                # Stand; hit again is an automatic bust
+                m += 1
+                #print(cards, total)
+
+            cards[i] = cards[i]+1
+
+    return(m)

--- a/blackjack/cython-array/setup.py
+++ b/blackjack/cython-array/setup.py
@@ -1,0 +1,6 @@
+from distutils.core import setup
+from Cython.Build import cythonize
+
+setup(
+    ext_modules = cythonize("partitions.pyx")
+)


### PR DESCRIPTION
I threw together a faster version of the cython solution. Basically I added some static types and compiler directives to ensure that the entire `partitions` function could be compiled down to C with minimal calls to python functions (only the `print` function). I also switched from passing a python list to an array since it has homogeneous typed data (you could similarly use a numpy array). You can see this by running `cythonize --annotate partitions.pyx` and look at the resulting `.html` file. 

I'm using cython 0.27.3 on OSX with clang 4.0.1 and python 3.6.4. When I run the `c` benchmark, I get:

```
real	0m0.054s
user	0m0.052s
sys	0m0.002s
```

With the new cython code I get:

```
real	0m0.132s
user	0m0.125s
sys	0m0.006s
```

compared to the original cython implementation:

```
real	0m5.313s
user	0m5.304s
sys	0m0.008s
```

I'm guessing the discrepancy in timings between this cython code and the c has something to do with the time it takes to acquire the typed memoryview of the `cards` array. You could probably eke out better performance by passing the raw pointer, but I didn't try that. 

Also I wanted to note that when I run the Numba code using Numba 0.36.2, I get:

```
real	0m0.534s
user	0m0.481s
sys	0m0.049s
```

so perhaps you're using an older version that's slower (Numba is a moving target in terms of performance and tends to get better each release). Also, part of what you're seeing is the jit compilation. If you change the signature to `numba.jit(nopython=True, cache=True)`, it caches the compilation to disk and the subsequent time that you run it, it won't have to re-jit the code. For me this drops another 100+ms:

```
real	0m0.418s
user	0m0.368s
sys	0m0.049s
```

I played around with using numpy arrays with the numba implementation as well as putting more of the code into a numba function, but I didn't get any big additional performance increase. I'm actually surprised, because recently I've found in most of my applications that numba is as fast or faster than cython for straight numerical code. It might have something to do with the recursion which I don't think much work has been done to improve the numba compiler for those use-cases. 

Hope this PR is interesting/useful and demonstrates cython's potential a bit better. 