### PR TITLE
Fix Rust semantics to more closely match C's.

### DIFF
--- a/blackjack/rust/outcomes.rs
+++ b/blackjack/rust/outcomes.rs
@@ -1,11 +1,14 @@
-fn partitions(mut cards: [usize; 10], subtotal: usize) -> i32 {
+type Count = u32;
+type Total = u32;
+
+fn partitions(cards: &mut [Count; 10], subtotal: Count) -> Total {
     let mut m=0;
     let mut total;
     // Hit
 
     for i in 0..10 {
         if cards[i]>0 {
-	    total = subtotal+i+1;
+	    total = subtotal+i as Count+1;
 	    if total < 21 {
 	        // Stand
 	        m += 1;
@@ -24,7 +27,7 @@ fn partitions(mut cards: [usize; 10], subtotal: usize) -> i32 {
     
 fn main() {
     
-    let mut deck: [usize; 10] = [4; 10];
+    let mut deck: [Count; 10] = [4; 10];
     deck[9] = 16;
     
     let mut d=0;
@@ -34,7 +37,7 @@ fn main() {
         let mut p = 0;
         for j in 0..10 {
             deck[j] -= 1;
-            let n = partitions(deck, j+1);
+            let n = partitions(&mut deck, j as Count+1);
             deck[j] += 1;
             p += n;
         }


### PR DESCRIPTION
On my computer, this brings it to about the same performance as C, at least with gcc -O3 (which I believe is running clang on this computer and hence is comparable to rustc -O3).  The main thing slowing it down was that in C, taking an array argument by value only passes the array pointer, while in Rust it moves the entire array; fixing it to use a reference to an array instead solves that problem.  Not that taking by reference is actually the idiomatic thing to do in Rust--people almost never pass arrays by value--so this is also fixing it to be more like Rust code in the wild.

Secondarily, the original code used usize in some places instead of u32--using u32 is closer to what the C is doing, and is also the default integer size in Rust.  I found it was slightly faster than using usize on my machine, which is not unexpected, but YMMV on that part.

While I suspect that it's possible to run a good bit faster than this algorithm by exploiting multithreading, my current machine has just one core so that's hard to test at the moment, and in any case I'm not sure whether you are trying to compare algorithms directly or not.